### PR TITLE
Add overloads to transform method

### DIFF
--- a/projects/ngx-filesize/src/lib/filesize.pipe.ts
+++ b/projects/ngx-filesize/src/lib/filesize.pipe.ts
@@ -10,6 +10,8 @@ export class FileSizePipe implements PipeTransform {
     return filesize(value, options);
   }
 
+  transform(value: number, options?: any): string;
+  transform(value: number[], options?: any): string[];
   transform(value: number | number[], options?: any) {
     if (Array.isArray(value)) {
       return value.map(val => FileSizePipe.transformOne(val, options));


### PR DESCRIPTION
Add the proper overloads to reflect the fact that this pipe will return a `string` if given a `string`, and a `string[]` if given a `string[]`. This provides accurate template type checking. For example, if a hypothetical `giveMeAString` directive expects a string, using this pipe to provide that string would have previously resulted in an error since the pipe's type signature always returned `string | string[]`.

```html
<!-- error TS2322: Type 'string | string[]' is not assignable to type 'string' -->
<my-component giveMeAString="myString | filesize"></my-component>
```