### PR TITLE
Move `filesize` to `peerDependencies`

### DIFF
--- a/packages/ngx-filesize-demo/package.json
+++ b/packages/ngx-filesize-demo/package.json
@@ -16,7 +16,7 @@
     "@angular/core": "^14.2.0",
     "@angular/platform-browser": "^14.2.0",
     "@angular/platform-browser-dynamic": "^14.2.0",
-    "filesize": "6.3.0",
+    "filesize": "^9.0.0",
     "ngx-filesize": "3.0.0-alpha.0",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/packages/ngx-filesize/README.md
+++ b/packages/ngx-filesize/README.md
@@ -1,17 +1,24 @@
 # `ngx-filesize`
 
-A [filesize.js](https://filesizejs.com) pipe for Angular
+A [filesize.js](https://filesizejs.com) pipe for Angular.
 
-## v2 Migration
+## 3.0.0 breaking changes
+- `ngx-filesize` now supports & requires Angular 14+.
+- `filesize` is now a peer dependency (`>= 6.0.0 < 10.0.0`, note `10` isn't supported), and so it must be installed alongside `ngx-filesize@^3`.
+
+## 2.0.0 breaking changes
 Pipe name was changed from `{{ 123 | bytes }}` to `{{ 123 | filesize }}`
 
 ## Usage:
-```
-npm install ngx-filesize
+
+```sh
+npm install ngx-filesize filesize@9
+# or 
+yarn add ngx-filesize filesize@9
 ```
 
-#### In your module:
-```typescript
+Import the `NgxFilesizeModule` into your own `NgModule`:
+```ts
 import {NgxFilesizeModule} from 'ngx-filesize';
 
 // ...
@@ -27,7 +34,7 @@ import {NgxFilesizeModule} from 'ngx-filesize';
 })
 ```
 
-#### In your component:
-```typescript
-{{bytes | filesize}}
+And use the pipe in your templates:
+```handlebars
+{{ 123 | filesize }}
 ```

--- a/packages/ngx-filesize/package.json
+++ b/packages/ngx-filesize/package.json
@@ -40,10 +40,10 @@
   "private": true,
   "peerDependencies": {
     "@angular/common": "^14.2.0",
-    "@angular/core": "^14.2.0"
+    "@angular/core": "^14.2.0",
+    "filesize": ">= 6.0.0 < 10.0.0"
   },
   "dependencies": {
-    "filesize": ">= 4.0.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
@@ -64,7 +64,7 @@
     "@typescript-eslint/eslint-plugin": "5.37.0",
     "@typescript-eslint/parser": "5.37.0",
     "eslint": "^8.23.1",
-    "filesize": "6.3.0",
+    "filesize": "^9.0.0",
     "jasmine-core": "~4.3.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.1.0",

--- a/packages/ngx-filesize/src/lib/filesize.pipe.spec.ts
+++ b/packages/ngx-filesize/src/lib/filesize.pipe.spec.ts
@@ -4,10 +4,10 @@ describe('FileSizePipe', () => {
   const pipe = new FileSizePipe();
 
   it('transforms 1337', () => {
-    expect(pipe.transform(1337)).toBe('1.31 KB');
+    expect(pipe.transform(1337)).toBe('1.34 kB');
   });
 
   it('transforms 1024', () => {
-    expect(pipe.transform(1024)).toBe('1 KB');
+    expect(pipe.transform(1024)).toBe('1.02 kB');
   });
 });

--- a/packages/ngx-filesize/src/lib/filesize.pipe.ts
+++ b/packages/ngx-filesize/src/lib/filesize.pipe.ts
@@ -1,12 +1,11 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import filesize_ from 'filesize';
+import filesize from 'filesize';
 
 @Pipe({
   name: 'filesize'
 })
 export class FileSizePipe implements PipeTransform {
   private static transformOne(value: number, options?: any): string {
-    const filesize = filesize_;
     return filesize(value, options);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5026,10 +5026,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filesize@npm:6.3.0":
-  version: 6.3.0
-  resolution: "filesize@npm:6.3.0"
-  checksum: dfc33b731f448b663879d4a56a4c5c5d4139da7890781e78be2bbeec1139e04037bda4d22639e4ee354ca83215463ffc0c1ef3cc7e16222eb578a229ba65edbe
+"filesize@npm:^9.0.0":
+  version: 9.0.11
+  resolution: "filesize@npm:9.0.11"
+  checksum: 7e8a9f9a4089e3ee29de64c241b50db8db4008351ace959873cb950bac0c2e1e09f4b45f42eaed8acd589a895dde978ed199e7a9982902fa06ca0be48e5ea92d
   languageName: node
   linkType: hard
 
@@ -6880,7 +6880,7 @@ __metadata:
     "@angular/platform-browser": ^14.2.0
     "@angular/platform-browser-dynamic": ^14.2.0
     "@types/jasmine": ~4.0.0
-    filesize: 6.3.0
+    filesize: ^9.0.0
     jasmine-core: ~4.3.0
     karma: ~6.4.0
     karma-chrome-launcher: ~3.1.0
@@ -6922,7 +6922,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 5.37.0
     "@typescript-eslint/parser": 5.37.0
     eslint: ^8.23.1
-    filesize: 6.3.0
+    filesize: ^9.0.0
     jasmine-core: ~4.3.0
     karma: ~6.4.0
     karma-chrome-launcher: ~3.1.0
@@ -6937,6 +6937,7 @@ __metadata:
   peerDependencies:
     "@angular/common": ^14.2.0
     "@angular/core": ^14.2.0
+    filesize: ">= 6.0.0 < 10.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
# Summary

This PR moves `filesize` to `peerDependencies` along with a defined support range of `>= 6.0.0 < 10.0.0`.

Seems supporting majors 6 through 9, along with 10 is a bit difficult as the imported value was changed in 10.0.0.