### PR TITLE
Raise `peerDep` to show Angular 15 support

### DIFF
--- a/packages/ngx-filesize/package.json
+++ b/packages/ngx-filesize/package.json
@@ -38,8 +38,8 @@
     "lint": "ng lint"
   },
   "peerDependencies": {
-    "@angular/common": "^14.2.0",
-    "@angular/core": "^14.2.0",
+    "@angular/common": ">= 14.2.0 < 16.0.0",
+    "@angular/core": ">= 14.2.0 < 16.0.0",
     "filesize": ">= 6.0.0 < 10.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7018,8 +7018,8 @@ __metadata:
     typescript: ~4.8.0
     zone.js: ~0.12.0
   peerDependencies:
-    "@angular/common": ^14.2.0
-    "@angular/core": ^14.2.0
+    "@angular/common": ">= 14.2.0 < 16.0.0"
+    "@angular/core": ">= 14.2.0 < 16.0.0"
     filesize: ">= 6.0.0 < 10.0.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Summary

I tested the existing version with Angular 15 and it works just fine.

I would upgrade the lib but that would raise the minimum peerDep to 15 as well, guess we'll be 1 major behind?