### PR TITLE
Bump actions, use `.nvmrc` file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        env:
+          SKIP_YARN_COREPACK_CHECK: true
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
- Bumps `actions/checkout` and `actions/setup-node`
- Use `node-version-file` instead of repeating the version in the file & CI definition
- Apply workaround mentioned in https://github.com/actions/setup-node/issues/531#issuecomment-1820618025